### PR TITLE
Add Linux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ let task = URLSession(configuration: .ephemeral).dataTask(with: req) { (data, re
         print(error)
     }
     else if let data = data {
-        print(String(data: data, encoding: .utf8) ?? "Does not look like an utf8 response :(")
+        print(String(data: data, encoding: .utf8) ?? "Does not look like a utf8 response :(")
     }
 }
 task.resume()

--- a/Sources/OhhAuth.swift
+++ b/Sources/OhhAuth.swift
@@ -22,6 +22,9 @@
 /// - Copyright: 2017
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 open class OhhAuth
 {


### PR DESCRIPTION
URLRequest object and other networking components have been separated into a different module (i.e. `FoundationNetworking`) in Linux-based systems and are not available anymore on Foundation.

This PR includes this new module, checking first whether it's available so that it still works in the Darwin kernel.

See: https://forums.swift.org/t/pitch-move-urlsession-to-new-foundationnetworking-module/14002?page=2